### PR TITLE
Export now supports multiple files.

### DIFF
--- a/src/aff4_directory.cc
+++ b/src/aff4_directory.cc
@@ -219,9 +219,9 @@ AFF4Status AFF4Directory::Flush() {
 }
 
 
-bool AFF4Directory::IsDirectory(const URN& urn) {
+bool AFF4Directory::IsDirectory(const URN& urn, bool must_exist) {
     std::string filename = urn.ToFilename();
-    return AFF4Directory::IsDirectory(filename);
+    return AFF4Directory::IsDirectory(filename, must_exist);
 }
 
 #ifdef _WIN32
@@ -292,7 +292,8 @@ AFF4Status AFF4Directory::MkDir(DataStore* resolver, const std::string& path) {
     return STATUS_OK;
 }
 
-bool AFF4Directory::IsDirectory(const std::string& filename) {
+bool AFF4Directory::IsDirectory(const std::string& filename,
+                                bool must_exist) {
     DWORD dwAttrib = GetFileAttributes(filename.c_str());
 
     bool result = (dwAttrib != INVALID_FILE_ATTRIBUTES &&
@@ -300,8 +301,10 @@ bool AFF4Directory::IsDirectory(const std::string& filename) {
 
     // If the URN ends with a / and we have permissions to create it, it is a
     // directory.
-    char last = *(filename.rbegin());
-    result |= (last == '/' || last == '\\');
+    if (!must_exist) {
+        char last = *(filename.rbegin());
+        result |= (last == '/' || last == '\\');
+    }
 
     return result;
 }
@@ -317,12 +320,13 @@ AFF4Status AFF4Directory::MkDir(DataStore *resolver, const std::string& path) {
     return STATUS_OK;
 }
 
-bool AFF4Directory::IsDirectory(const std::string& filename) {
+bool AFF4Directory::IsDirectory(const std::string& filename,
+                                bool must_exist) {
     DIR* dir = opendir(filename.c_str());
     if (!dir) {
         // If the URN ends with a / and we have permissions to create it, it is a
         // directory.
-        if (*(filename.rbegin()) == PATH_SEP) {
+        if (!must_exist && *(filename.rbegin()) == PATH_SEP) {
             return true;
         }
 

--- a/src/aff4_directory.h
+++ b/src/aff4_directory.h
@@ -60,8 +60,8 @@ class AFF4Directory: public AFF4Volume {
     virtual AFF4Status Flush();
 
     // Some handy static methods.
-    static bool IsDirectory(const URN& urn);
-    static bool IsDirectory(const std::string& filename);
+    static bool IsDirectory(const URN& urn, bool must_exist=false);
+    static bool IsDirectory(const std::string& filename, bool must_exist=false);
     static AFF4Status RemoveDirectory(DataStore *resolver, const std::string& root_path);
     static AFF4Status MkDir(DataStore *resolver, const std::string& path);
 };

--- a/src/aff4_file.cc
+++ b/src/aff4_file.cc
@@ -60,7 +60,7 @@ AFF4Status _CreateIntermediateDirectories(
         resolver->logger->debug("Creating intermediate directories {}",
                                 path);
 
-        if (AFF4Directory::IsDirectory(path)) {
+        if (AFF4Directory::IsDirectory(path, /* must_exist= */ true)) {
             continue;
         }
 
@@ -99,7 +99,7 @@ AFF4Status FileBackedObject::LoadFromURN() {
         return INVALID_INPUT;
     }
 
-    resolver->logger->info("Opening file {}", filename);
+    resolver->logger->debug("Opening file {}", filename);
 
     std::vector<std::string> directory_components = split(filename, PATH_SEP);
     directory_components.pop_back();
@@ -112,7 +112,8 @@ AFF4Status FileBackedObject::LoadFromURN() {
         desired_access |= GENERIC_WRITE;
 
         // Next call will append.
-        resolver->Set(urn, AFF4_STREAM_WRITE_MODE, new XSDString("append"));
+        resolver->Set(urn, AFF4_STREAM_WRITE_MODE, new XSDString("append"),
+                      /* replace = */ true);
         properties.writable = true;
 
         // Only create directories if we are allowed to.
@@ -295,7 +296,7 @@ AFF4Status FileBackedObject::LoadFromURN() {
         }
     }
 
-    resolver->logger->info("Opening file {}", filename);
+    resolver->logger->debug("Opening file {}", filename);
 
     fd = open(filename.c_str(), flags,
               S_IRWXU | S_IRWXG | S_IRWXO);

--- a/src/data_store.cc
+++ b/src/data_store.cc
@@ -532,7 +532,8 @@ AFF4Status MemoryDataStore::Has(const URN& urn, const URN& attribute) {
     return STATUS_OK;
 }
 
-AFF4Status MemoryDataStore::Has(const URN& urn, const URN& attribute, RDFValue& value) {
+AFF4Status MemoryDataStore::Has(const URN& urn, const URN& attribute,
+                                const RDFValue& value) {
     auto urn_it = store.find(urn.SerializeToString());
 
     if (urn_it == store.end()) {

--- a/src/data_store.h
+++ b/src/data_store.h
@@ -358,7 +358,8 @@ class DataStore {
     /**
      * Does the given URN have the given attribute set to the given value.
      */
-    virtual AFF4Status Has(const URN& urn, const URN& attribute, RDFValue& value) = 0;
+    virtual AFF4Status Has(const URN& urn, const URN& attribute,
+                           const RDFValue& value) = 0;
 
     /**
      * Does the given URN have the given attribute set
@@ -640,7 +641,7 @@ class MemoryDataStore: public DataStore {
     AFF4Status Get(const URN& urn, const URN& attribute, std::vector<std::shared_ptr<RDFValue>>& value);
     AFF4Status Has(const URN& urn);
     AFF4Status Has(const URN& urn, const URN& attribute);
-    AFF4Status Has(const URN& urn, const URN& attribute, RDFValue& value);
+    AFF4Status Has(const URN& urn, const URN& attribute, const RDFValue& value);
 
     std::unordered_set<URN> Query(
         const URN& attribute, const RDFValue* value = nullptr) override;

--- a/src/lexicon.inc
+++ b/src/lexicon.inc
@@ -91,7 +91,7 @@ LEXICON_DEFINE(AFF4_ZIP_SEGMENT_TYPE, "http://aff4.org/Schema#zip_segment");
  * AFF4 Primary Object Types.
  *
  * Note: These types are abstract entities which refer to a logical
- * image. They do not say anything about the actual storage methos
+ * image. They do not say anything about the actual storage methods
  * used. Instead they refer to the AFF4 stream which stores the data
  * in their dataStream attribute.
  *


### PR DESCRIPTION
Files to export can be specified as a glob or read from stdin. Also
added -l option to just list all the URNs in the volume.

Supported use cases:

- Export files based on glob
 ./aff4imager -e '*.exe'  /tmp/test.aff4 -d -d

- Export files based on grep expressions
  ./aff4imager -l /tmp/test.aff4 | grep zip | ./aff4imager -e @
  /tmp/test.aff4 -d -d --export_dir /tmp/export/

- Acquisition based on arbitrary file attributes:
  find /bin/ -size +100k | ./aff4imager -i @ -o /tmp/test.aff4 -t -d -d