### PR TITLE
Fixed linpmem kcore detection.

### DIFF
--- a/src/data_store.h
+++ b/src/data_store.h
@@ -605,7 +605,16 @@ class DataStore {
     std::unordered_map<std::string, std::shared_ptr<AFF4Stream>> SymbolicStreams;
 
     /// These types will not be dumped * to turtle files.
-    std::unordered_map<std::string, std::unordered_set<std::string>> suppressed_rdftypes;
+    std::unordered_map<
+        std::string, std::unordered_set<std::string>> suppressed_rdftypes;
+
+    // Should we suppress this tuple from the turtle file? We do not
+    // want to write facts in the turtle file which are self evident
+    // from context. For example, the AFF4_STORED attribute of
+    // AFF4_ZIP_SEGMENT_TYPE are inferred from the Zip container
+    // itself.
+    virtual bool ShouldSuppress(const URN& subject, const URN& predicate,
+                                const std::string& value);
 
 };
 

--- a/tools/pmem/Makefile.am
+++ b/tools/pmem/Makefile.am
@@ -48,14 +48,11 @@ endif
 
 if LINUX
 bin_PROGRAMS = linpmem
-
 linpmem_LDFLAGS = $(STATIC_LINKERLDFLAGS)
 linpmem_CXXFLAGS = -std=c++11 -g -Wall -O0
-linpmem_SOURCES = pmem_imager.cc linux_pmem.cc
+linpmem_SOURCES = pmem_imager.cc linux_pmem.cc ../../src/compatibility.cc
 linpmem_LDADD = -laff4
-
 all-local: linpmem
-
 endif
 
 if OSX

--- a/tools/pmem/linux_pmem.h
+++ b/tools/pmem/linux_pmem.h
@@ -21,6 +21,11 @@ specific language governing permissions and limitations under the License.
 
 namespace aff4 {
 
+struct ram_range {
+    aff4_off_t start;
+    aff4_off_t length;
+};
+
 class LinuxPmemImager: public PmemImager {
  protected:
     virtual std::string GetName() {
@@ -36,7 +41,7 @@ class LinuxPmemImager: public PmemImager {
   virtual AFF4Status ImagePhysicalMemory();
  private:
   AFF4Status CreateMap_(AFF4Map *map, aff4_off_t *length);
-  AFF4Status ParseIOMap_(std::vector<aff4_off_t> *ram);
+  AFF4Status ParseIOMap_(std::vector<ram_range> *ram);
 };
 
 } // namespace aff4


### PR DESCRIPTION
This works better on older kernels which have pheader.paddr == 0.

Also fixed the tuple suppression code. We now omit the following
tuples:

 - AFF4_STORED for AFF4_ZIP_SEGMENT_TYPE, AFF4_ZIP_TYPE,
   AFF4_DIRECTORY_TYPE
 - AFF4_TYPE attributes of the above objects.

This is because these types are deduced from parsing their respective
containers.